### PR TITLE
[#24] Establish inter-kraftizen comms

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,15 @@
 import { performTask } from './utils/actions/performTask';
 import Kraftizen from './utils/Kraftizen';
+import TeamMessenger from './utils/TeamMessenger';
 
 const kraftizenRoster: Kraftizen[] = [];
 
 const botNames = ['Kazuma', 'Miko', 'Nakanaka', 'Gilbert'];
 
+const messenger = new TeamMessenger(kraftizenRoster);
+
 botNames
-  .map((username) => ({ host: 'localhost', port: 62228, username }))
+  .map((username) => ({ host: 'localhost', port: 62228, username, messenger }))
   .forEach((kraftizenOpts) => {
     kraftizenRoster.push(new Kraftizen(kraftizenOpts, performTask));
   });

--- a/src/utils/TeamMessenger.ts
+++ b/src/utils/TeamMessenger.ts
@@ -1,0 +1,29 @@
+import Kraftizen from './Kraftizen';
+import EventEmitter from 'events';
+
+export default class TeamMessenger {
+  teamMembers: Kraftizen[] = [];
+  emitter = new EventEmitter();
+
+  constructor(teamMembers: Kraftizen[]) {
+    this.teamMembers = teamMembers;
+  }
+
+  public messageTeam = (message: TeamMessage) => {
+    // Todo: this is a function call because we can, but maybe leverage actual events
+    setImmediate(() => {
+      this.teamMembers
+        .filter(
+          (kraftizen) => kraftizen.bot.username !== message.sender.bot.username
+        )
+        .forEach((kraftizen) => {
+          kraftizen.onTeamMessage(message);
+        });
+    });
+  };
+}
+
+export type TeamMessage = {
+  sender: Kraftizen;
+  message: string;
+};

--- a/src/utils/actions/performTask.ts
+++ b/src/utils/actions/performTask.ts
@@ -42,7 +42,12 @@ type TaskPayloadByType =
       type: Task.visit;
       position: Position;
     }
-  | { type: Task.hunt; entity?: Entity; verbose?: boolean }
+  | {
+      type: Task.hunt;
+      entity?: Entity;
+      verbose?: boolean;
+      forceMelee?: boolean;
+    }
   | {
       type: Task.return | Task.collect | Task.setHome;
     };
@@ -61,7 +66,12 @@ export const performTask = async (task: TaskPayload, kraftizen: Kraftizen) => {
         await behaviors.toPlayer(task.username);
         break;
       case Task.hunt:
-        await behaviors.attackNearest(task.entity, 30, task.verbose);
+        await behaviors.attackNearest(
+          task.entity,
+          30,
+          task.verbose,
+          task.forceMelee
+        );
         break;
       case Task.return:
         await behaviors.toCoordinate(kraftizen.homePoint);

--- a/src/utils/actions/queuePersonaTasks.ts
+++ b/src/utils/actions/queuePersonaTasks.ts
@@ -60,13 +60,31 @@ export const queuePersonaTasks = async (kraftizen: Kraftizen) => {
         );
 
         if (complain)
-          sendChat(kraftizen.bot, 'I have no weapons but I am a guard');
+          sendChat(kraftizen.bot, 'I have no weapons but I am a guard', {
+            chance: 0.5,
+          });
       }
 
       break;
     default:
       handleBoredom(kraftizen);
       break;
+  }
+
+  queueStandardTasks(kraftizen);
+};
+
+const queueStandardTasks = async (kraftizen: Kraftizen) => {
+  if (Math.random() < 0.1) {
+    /* Usually we should get attacked and respond anyway */
+    const nearbyEnemy = kraftizen.behaviors.getNearestHostileMob(5);
+
+    if (nearbyEnemy && kraftizen.taskQueue.length <= 1) {
+      kraftizen.addTask({
+        type: Task.hunt,
+        entity: nearbyEnemy,
+      });
+    }
   }
 };
 

--- a/src/utils/bot.utils.ts
+++ b/src/utils/bot.utils.ts
@@ -1,3 +1,4 @@
+import { Movements } from 'mineflayer-pathfinder';
 import { Entity, KraftizenBot, Persona, Position } from './types';
 
 export const botPosition = (bot: KraftizenBot): Position => {
@@ -28,7 +29,7 @@ export const getNearestHostileMob = (
 ) => {
   const nearestHostiles = getKnownHostileMobs(bot).filter(additionalFilter);
 
-  if (nearestHostiles?.[0].position.distanceTo(bot.entity.position) < range) {
+  if (nearestHostiles?.[0]?.position.distanceTo(bot.entity.position) < range) {
     return nearestHostiles[0];
   }
 };
@@ -38,4 +39,15 @@ export const getNearestHostileMob = (
  */
 export const personaReturnsHome = (persona: Persona) => {
   return ![Persona.follower, Persona.none].includes(persona);
+};
+
+export const getDefaultMovements = (bot: KraftizenBot) => {
+  const movement = new Movements(bot);
+
+  movement.canOpenDoors = true;
+  movement.digCost = 10;
+  movement.placeCost = 3;
+  movement.allowEntityDetection = true;
+
+  return movement;
 };


### PR DESCRIPTION
Allows kraftizens to ask each other for help.

Establishes this in a strict function call method. May wish to split this to an event based system in the future, especially if running bots in different threads.

Resolves #24