### PR TITLE
Personal ratelimiters, re-org some behaviors

### DIFF
--- a/src/Kraftizen.ts
+++ b/src/Kraftizen.ts
@@ -5,23 +5,23 @@ const autoEat = require('fix-esm').require('mineflayer-auto-eat').plugin;
 import armorManager from 'mineflayer-armor-manager';
 import hawkeye from 'minecrafthawkeye';
 
-import { KraftizenBot, Persona, Position } from './types';
+import { KraftizenBot, Persona, Position } from './utils/types';
 import { Movements } from 'mineflayer-pathfinder';
-import { botPosition, getDefaultMovements } from './bot.utils';
-import { greet } from './actions/greet';
-import { calculateDistance3D, getRandomIntInclusive, sleep } from './utils';
-import BehaviorsEngine from './actions/behaviors';
-import { Task, TaskPayload } from './actions/performTask';
-import { performTask } from './actions/performTask';
-import { queuePersonaTasks } from './actions/queuePersonaTasks';
-import { sendChat } from '../character/chatLines';
-import TeamMessenger, { TeamMessage } from './TeamMessenger';
-import rateLimiter from './RateLimiter';
-
-rateLimiter.setLimitForKey('demandHelp', {
-  max: 1,
-  windowMs: 1000 * 30,
-});
+import { botPosition, getDefaultMovements } from './utils/bot.utils';
+import { greet } from './utils/actions/greet';
+import {
+  calculateDistance3D,
+  getRandomIntInclusive,
+  sleep,
+} from './utils/utils';
+import BehaviorsEngine from './utils/actions/behaviors';
+import { Task, TaskPayload } from './utils/actions/performTask';
+import { performTask } from './utils/actions/performTask';
+import { queuePersonaTasks } from './utils/actions/queuePersonaTasks';
+import { sendChat } from './character/chatLines';
+import TeamMessenger, { TeamMessage } from './utils/TeamMessenger';
+import { getRateLimiter } from './utils/RateLimiter';
+import QueueManager from './utils/QueueManager';
 
 export default class Kraftizen {
   /** Reference to the core bot brain */
@@ -39,17 +39,15 @@ export default class Kraftizen {
   lord: string | null = null;
   lastCommandFrom: string | null = null;
 
-  taskQueue: TaskPayload[] = [];
-
+  tasks = new QueueManager();
   behaviors: BehaviorsEngine;
+  rateLimiter = getRateLimiter();
 
   username: string;
 
   private defaultMove: Movements;
   private mcData: ReturnType<typeof minecraftData>;
   private messenger: TeamMessenger;
-
-  currentTask: TaskPayload;
 
   constructor(
     options: mineflayer.BotOptions & { messenger: TeamMessenger },
@@ -131,16 +129,32 @@ export default class Kraftizen {
         const slotsEmpty = this.bot.inventory.emptySlotCount();
         // todo: const
         if (slotsEmpty < 4)
-          this.addTask({ type: Task.findChest, deposit: true });
+          this.addTask({ type: Task.findBlock, deposit: true });
       }
     });
 
     this.bot.on('chat', this.handleChat);
 
+    this.bot.on('death', () => {
+      /** Return to death point */
+      this.tasks.dropAllTasks();
+      this.tasks.addTasks(
+        [
+          {
+            type: Task.visit,
+            position: this.bot.entity.position,
+          },
+        ],
+        true
+      );
+      this.tasks.blockTasksForMs(5000);
+    });
     this.bot.on('respawn', () => {
+      this.bot.chat('Oops');
       this.addTasks([
         { type: Task.return },
-        { type: Task.findChest, withdraw: true, multiple: true },
+        { type: Task.collect },
+        { type: Task.findBlock, withdraw: true, multiple: true },
       ]);
     });
 
@@ -150,7 +164,7 @@ export default class Kraftizen {
     });
 
     this.bot.on('wake', () => {
-      this.dropAllTasks();
+      this.tasks.dropAllTasks();
       this.addTask({ type: Task.return });
     });
 
@@ -158,27 +172,18 @@ export default class Kraftizen {
       const entity = this.bot.entities[packet.entityId];
 
       /** Already fighting */
-      if (this.hasTask(Task.hunt)) return;
+      if (this.tasks.firstTaskIs(Task.hunt)) return;
 
       if (entity.uuid === this.bot.entity.uuid) {
         this.addTask({ type: Task.hunt });
-        if (
-          this.bot.health < 8 &&
-          rateLimiter.tryCall('demandHelp', this.bot.username)
-        ) {
-          this.addTask({ type: Task.return });
+        if (this.bot.health < 8 && this.rateLimiter.tryCall('demandHelp')) {
+          this.addTasks([{ type: Task.return }, { type: Task.eat }]);
           this.bot.chat('help!');
           this.messageOthers({ message: 'help' });
         }
       }
     });
   };
-
-  public removeTasksOfType = (taskType: Task) => {
-    this.taskQueue = this.taskQueue.filter((task) => task.type === taskType);
-  };
-
-  public hasTask = (task: Task) => this.taskQueue.find((i) => i.type === task);
 
   public distanceFromHome = (position?: Position) => {
     return calculateDistance3D(
@@ -224,8 +229,11 @@ export default class Kraftizen {
           getRandomIntInclusive(100, 1000)
         );
         break;
+      case 'eat':
+        this.behaviors.eat(true);
+        break;
       case 'follow':
-        this.dropAllTasks();
+        this.tasks.dropAllTasks();
         this.bot.chat(`I will follow you, ${username}.`);
         this.previousPersona = this.persona;
         this.persona = Persona.follower;
@@ -252,7 +260,7 @@ export default class Kraftizen {
       case 'deposit':
       case 'unload':
         this.addTask({
-          type: Task.findChest,
+          type: Task.findBlock,
           deposit: true,
           verbose: true,
         });
@@ -262,11 +270,11 @@ export default class Kraftizen {
         break;
       case 'come':
       case 'here':
-        this.dropAllTasks();
-        this.taskQueue.unshift({ type: Task.come, username, oneTime: true });
+        this.tasks.dropAllTasks();
+        this.tasks.addTask({ type: Task.come, username, oneTime: true });
         break;
       case 'camp here':
-        this.taskQueue.unshift({
+        this.tasks.addTask({
           type: Task.come,
           username,
           oneTime: true,
@@ -274,7 +282,7 @@ export default class Kraftizen {
         });
         break;
       case 'hunt':
-        this.taskQueue.unshift({ type: Task.hunt, verbose: true });
+        this.tasks.addTask({ type: Task.hunt, verbose: true });
         break;
       case 'nearby':
         console.log(this.bot.entities);
@@ -283,11 +291,13 @@ export default class Kraftizen {
         this.behaviors.listInventory();
         break;
       case 'current task':
-        this.bot.chat(`My current task is to ${this.currentTask ?? 'idle'}`);
+        this.bot.chat(
+          `My current task is to ${this.tasks.currentTask.type ?? 'idle'}`
+        );
         break;
       case 'return':
         sendChat(this.bot, 'returning');
-        this.taskQueue.unshift({ type: Task.return });
+        this.tasks.addTask({ type: Task.return });
         break;
       case 'prefer melee':
         // TODO: improve commanding
@@ -297,9 +307,10 @@ export default class Kraftizen {
       case 'sleep':
         this.behaviors.goSleep();
         break;
+      case 'withdraw':
       case 'stock up':
-        this.taskQueue.unshift({
-          type: Task.findChest,
+        this.tasks.addTask({
+          type: Task.findBlock,
           verbose: true,
           withdraw: true,
           multiple: true,
@@ -328,8 +339,7 @@ export default class Kraftizen {
   };
 
   public addTask = (task: TaskPayload, atEnd = false) => {
-    if (atEnd) this.taskQueue.push(task);
-    else this.taskQueue.unshift(task);
+    this.tasks.addTask(task, atEnd);
   };
 
   public addTasks = (tasks: TaskPayload[], atEnd = false) => {
@@ -340,30 +350,21 @@ export default class Kraftizen {
     }
   };
 
-  public finishCurrentTask = () => {
-    this.currentTask = null;
-  };
-
-  private dropAllTasks = () => {
-    this.finishCurrentTask();
-    this.taskQueue = [];
-  };
-
   /**
    * Main behaviors loop
    */
   private loop = async () => {
     let delay = 2000;
     try {
-      const nextTask = this.taskQueue.shift();
+      const nextTask = this.tasks.nextTask();
 
-      if (nextTask && !this.currentTask) {
-        this.currentTask = nextTask;
+      if (nextTask && !this.tasks.currentTask) {
+        this.tasks.currentTask = nextTask;
         await this.performTask(nextTask);
         delay = 500;
       }
 
-      if (this.taskQueue.length === 0) {
+      if (this.tasks.isEmpty()) {
         await queuePersonaTasks(this);
       }
     } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { performTask } from './utils/actions/performTask';
-import Kraftizen from './utils/Kraftizen';
+import Kraftizen from './Kraftizen';
 import TeamMessenger from './utils/TeamMessenger';
 
 const kraftizenRoster: Kraftizen[] = [];

--- a/src/utils/QueueManager.ts
+++ b/src/utils/QueueManager.ts
@@ -1,0 +1,56 @@
+import { Task, TaskPayload } from './actions/performTask';
+
+export default class QueueManager {
+  taskQueue: TaskPayload[] = [];
+  currentTask: TaskPayload;
+  paused = false;
+  pausedTimer: null | ReturnType<typeof setTimeout>;
+
+  public removeTasksOfType = (taskType: Task) => {
+    this.taskQueue = this.taskQueue.filter((task) => task.type === taskType);
+  };
+
+  public hasTask = (task: Task) => this.taskQueue.find((i) => i.type === task);
+
+  public addTask = (task: TaskPayload, atEnd = false) => {
+    if (atEnd) this.taskQueue.push(task);
+    else this.taskQueue.unshift(task);
+  };
+
+  public addTasks = (tasks: TaskPayload[], atEnd = false) => {
+    if (atEnd) {
+      tasks.forEach((task) => this.addTask(task, atEnd));
+    } else {
+      tasks.reverse().forEach((task) => this.addTask(task));
+    }
+  };
+
+  public finishCurrentTask = () => {
+    this.currentTask = null;
+  };
+
+  public blockTasksForMs = (delay: number) => {
+    if (this.pausedTimer) clearTimeout(this.pausedTimer);
+    this.paused = true;
+    this.pausedTimer = setTimeout(() => {
+      this.pausedTimer = null;
+      this.paused = false;
+    }, delay);
+  };
+
+  public dropAllTasks = () => {
+    this.finishCurrentTask();
+    this.taskQueue = [];
+  };
+
+  public firstTaskIs = (task: Task) => {
+    return this.taskQueue[0]?.type === task;
+  };
+
+  public nextTask = () => {
+    if (this.paused) return null;
+    return this.taskQueue.shift();
+  };
+
+  public isEmpty = () => this.taskQueue.length === 0;
+}

--- a/src/utils/RateLimiter.ts
+++ b/src/utils/RateLimiter.ts
@@ -17,7 +17,7 @@ class RateLimiter {
   }
 
   /** Check if the request can go through */
-  tryCall(key: string, id?: string): boolean {
+  tryCall(key: RateLimiterKeys | string, id?: string): boolean {
     const options = this.limits.get(key) || this.defaultOptions;
     const now = Date.now();
     const record = this.counts.get(`${key}-${id}`);
@@ -34,7 +34,45 @@ class RateLimiter {
   }
 }
 
+export enum RateLimiterKeys {
+  checkChests = 'checkChests',
+  unarmedGuard = 'unarmedGuard',
+  findBed = 'findBed',
+  demandHelp = 'demandHelp',
+}
+
+/** Global limiter */
 export default new RateLimiter({
   windowMs: 1000 * 60 /* once a min */,
   max: 1,
 });
+
+export const getRateLimiter = () => {
+  const rateLimiter = new RateLimiter({
+    windowMs: 1000 * 60 /* once a min */,
+    max: 1,
+  });
+
+  /* Apply defaults */
+  rateLimiter.setLimitForKey('checkChests', {
+    max: 1,
+    windowMs: 1000 * 60 * 5,
+  });
+
+  rateLimiter.setLimitForKey('unarmedGuard', {
+    max: 1,
+    windowMs: 1000 * 60 * 30,
+  });
+
+  rateLimiter.setLimitForKey('findBed', {
+    max: 1,
+    windowMs: 1000 * 60 * 60 * 10,
+  });
+
+  rateLimiter.setLimitForKey('demandHelp', {
+    max: 1,
+    windowMs: 1000 * 30,
+  });
+
+  return rateLimiter;
+};

--- a/src/utils/TeamMessenger.ts
+++ b/src/utils/TeamMessenger.ts
@@ -1,4 +1,4 @@
-import Kraftizen from './Kraftizen';
+import Kraftizen from '../Kraftizen';
 import EventEmitter from 'events';
 
 type ItemClaim = 'bed';

--- a/src/utils/actions/itemActions.ts
+++ b/src/utils/actions/itemActions.ts
@@ -1,4 +1,4 @@
-import Kraftizen from '../Kraftizen';
+import Kraftizen from '../../Kraftizen';
 import { KraftizenBot, Position } from '../types';
 import { sleep } from '../utils';
 
@@ -15,6 +15,8 @@ const searchItems = [
   'crossbow',
   'arrow',
 ];
+
+const keep = ['food', 'arrow'];
 
 const maxWithdraw = 10;
 const maxToWithdrawOverrides: Record<string, number> = {
@@ -34,9 +36,9 @@ const itemMatches = (bot: KraftizenBot, itemType: string, item: Item) => {
   );
 };
 
-const getAllHeldItems = (bot: KraftizenBot) => {
-  return [...bot.entity.equipment, bot.inventory.slots].flatMap((i) =>
-    !!i ? i : []
+const getAllHeldItems = (bot: KraftizenBot, equip: boolean = true) => {
+  return [...(equip ? bot.entity.equipment : []), bot.inventory.slots].flatMap(
+    (i) => (!!i ? i : [])
   );
 };
 
@@ -48,6 +50,11 @@ const equipTiers = [
   'wooden',
   'golden',
 ];
+
+export const getFood = async (bot: KraftizenBot) => {
+  const list = getAllHeldItems(bot);
+  return list.find((item) => itemMatches(bot, 'food', item));
+};
 
 export const equipRanged = async (bot: KraftizenBot) => {
   let matches = bot.inventory
@@ -104,7 +111,7 @@ export const depositItems = async (
   kraftizen: Kraftizen,
   position: Position
 ) => {
-  const nearbyChest = kraftizen.behaviors.findChest(
+  const nearbyChest = kraftizen.behaviors.findBlock(
     rangeToChestOpen,
     undefined,
     undefined,
@@ -123,7 +130,7 @@ export const depositItems = async (
   const allItems = getAllHeldItems(kraftizen.bot);
   const depositList = allItems.filter(
     (item) =>
-      !searchItems.some(
+      !keep.some(
         (itemType) => item && itemMatches(kraftizen.bot, itemType, item)
       )
   );
@@ -151,7 +158,7 @@ export const withdrawItems = async (
   kraftizen: Kraftizen,
   position: Position
 ) => {
-  const nearbyChest = kraftizen.behaviors.findChest(
+  const nearbyChest = kraftizen.behaviors.findBlock(
     rangeToChestOpen,
     undefined,
     undefined,

--- a/src/utils/bot.utils.ts
+++ b/src/utils/bot.utils.ts
@@ -58,6 +58,7 @@ export const getDefaultMovements = (bot: KraftizenBot) => {
   movement.digCost = 500;
   movement.placeCost = 3;
   movement.allowEntityDetection = true;
+
   // movement.canDig = false;
 
   return movement;


### PR DESCRIPTION
- Organizes task queue into the queue manager
- Moves ratelimiter to per-bot
- Implement a manual eat
- Transform find chest to find block behavior